### PR TITLE
forms: use uasort instead of usort

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -942,12 +942,14 @@ class DynamicFormEntry extends VerySimpleModel {
 
                 $a->save();
             }
-            // Sort the form the way it is declared to be sorted
-            if ($this->_fields)
-                usort($this->_fields,
-                    function($a, $b) {
-                        return $a->get('sort') - $b->get('sort');
-                });
+        }
+
+        // Sort the form the way it is declared to be sorted
+        if ($this->_fields) {
+            uasort($this->_fields,
+                function($a, $b) {
+                    return $a->get('sort') - $b->get('sort');
+            });
         }
     }
 


### PR DESCRIPTION
- Preserve the fields indexed keys
- Only sort the fields once, after adding missing fields
