### PR TITLE
Temporary solution for tasks queue issue with custom queues

### DIFF
--- a/include/staff/tasks.inc.php
+++ b/include/staff/tasks.inc.php
@@ -284,7 +284,7 @@ if ($thisstaff->hasPerm(Task::PERM_DELETE, false)) {
   <div class="pull-right" style="height:25px">
     <span class="valign-helper"></span>
     <?php
-        require STAFFINC_DIR.'templates/queue-sort.tmpl.php';
+        require STAFFINC_DIR.'templates/tasks-queue-sort.tmpl.php';
     ?>
    </div>
     <form action="tasks.php" method="get" onsubmit="javascript:

--- a/include/staff/templates/tasks-queue-sort.tmpl.php
+++ b/include/staff/templates/tasks-queue-sort.tmpl.php
@@ -1,0 +1,33 @@
+
+<span class="action-button muted" data-dropdown="#sort-dropdown" data-toggle="tooltip" title="<?php echo $sort_options[$sort_cols]; ?>">
+  <i class="icon-caret-down pull-right"></i>
+  <span><i class="icon-sort-by-attributes-alt <?php if ($sort_dir) echo 'icon-flip-vertical'; ?>"></i> <?php echo __('Sort');?></span>
+</span>
+<div id="sort-dropdown" class="action-dropdown anchor-right"
+onclick="javascript:
+var query = addSearchParam({'sort': $(event.target).data('mode'), 'dir': $(event.target).data('dir')});
+$.pjax({
+    url: '?' + query,
+    timeout: 2000,
+    container: '#pjax-container'});">
+  <ul class="bleed-left">
+    <?php foreach ($queue_sort_options as $mode) {
+    $desc = $sort_options[$mode];
+    $icon = '';
+    $dir = '0';
+    $selected = $sort_cols == $mode; ?>
+    <li <?php
+    if ($selected) {
+    echo 'class="active"';
+    $dir = ($sort_dir == '1') ? '0' : '1'; // Flip the direction
+    $icon = ($sort_dir == '1') ? 'icon-hand-up' : 'icon-hand-down';
+    }
+    ?>>
+        <a href="#" data-mode="<?php echo $mode; ?>" data-dir="<?php echo $dir; ?>">
+          <i class="icon-fixed-width <?php echo $icon; ?>"
+          ></i> <?php echo Format::htmlchars($desc); ?></a>
+      </li>
+    <?php } ?>
+ </ul>
+</div>
+


### PR DESCRIPTION
This is temporary workaround for issue mentioned by @kest874:

`Fatal error: Call to a member function getSortOptions() on null in /var/www/osttest/include/staff/templates/queue-sort.tmpl.php on line 2`

It puts back old `queue-sort.tmpl.php` renamed as `tasks-queue-sort.tmpl.php` and updates `tasks.inc.php` to use it instead of new `queue-sort.tmpl.php`. With this the tasks queue is shown normally.

This change should be reverted once tasks queues are remade with custom queues.
